### PR TITLE
Find a way around invokelatest(#23)

### DIFF
--- a/src/examples.jl
+++ b/src/examples.jl
@@ -74,18 +74,16 @@ mix = @model (K,α) begin
 end
 
 export linReg1D
-linReg1D = @model (x,y) begin
-    # Priors chosen following Gelman(2008)
-    α ~ Cauchy(0,10)
-    β ~ Cauchy(0,2.5)
-    σ ~ HalfCauchy(3)
 
-    ŷ = α .+ β .* x
-    N = length(x)
-    y ~ For(1:N) do n
-        Normal(ŷ[n], σ)
+linReg1D_local(ŷ, σ) = n -> Normal(ŷ[n])
+linReg1D = @model (x, y) begin
+        α ~ Cauchy(0, 10)
+        β ~ Cauchy(0, 2.5)
+        σ ~ HalfCauchy(3)
+        ŷ = α .+ β .* x
+        N = length(x)
+        y ~ For(linReg1D_local(ŷ, σ), 1:N)
     end
-end
 
 
 # From OpenBUGS and section 6 of Gelfand et al.

--- a/src/model.jl
+++ b/src/model.jl
@@ -98,8 +98,6 @@ function Base.show(io::IO, m::Model)
     print(io, convert(Expr, m))
 end
 
-
-
 function Base.convert(::Type{Expr}, m::Model)
     numArgs = length(m.args)
     args = if numArgs == 1

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -450,3 +450,65 @@ end
 
 # @btime invokefrozen(f, Int; a=3,b=4)  # 3.466 ns (0 allocations: 0 bytes)
 # @btime f(;a=3,b=4)                    # 1.152 ns (0 allocations: 0 bytes)
+
+
+abstract type TypeLevel end
+struct TLCons{Hd, Tl} <: TypeLevel end
+struct TLNil <: TypeLevel end
+struct TLVal{Val} <: TypeLevel end
+struct TLSExp{Fn, Args} <: TypeLevel end
+
+function typelevellist(l)
+    foldr(l, init=TLNil) do each, prev
+        TLCons{each, prev}
+    end
+end
+
+function expr2typelevel(x)
+    r = expr2typelevel
+    @match x begin
+        Expr(hd, tl...) =>
+            let hd = r(hd),
+                tl = map(r, tl) |> typelevellist,
+                f = TLVal{Expr},
+                args = TLCons{hd, tl}
+            TLSExp{f, args}
+            end
+        ln :: LineNumberNode =>
+            let f = TLVal{LineNumberNode},
+               args = [
+                    r(ln.line),
+                    r(ln.file)
+                ] |> typelevellist
+            TLSExp{f, args}
+            end
+        x::QuoteNode =>
+            let f = TLVal{QuoteNode},
+                args = [r(x.value)] |> typelevellist
+
+            TLSExp{f, args}
+            end
+        a => TLVal{a}
+    end
+end
+
+
+function interpret(t::Type{TLNil})
+    []
+end
+
+function interpret(t::Type{TLVal{Val}}) where Val
+    Val
+end
+
+function interpret(t::Type{TLCons{Hd, Tl}}) where {Hd, Tl}
+    tl = interpret(Tl)
+    @assert tl isa Vector
+    [interpret(Hd), tl...]
+end
+
+function interpret(t::Type{TLSExp{Fn, Args}}) where {Fn, Args}
+    args = interpret(Args)
+    @assert args isa Vector
+    interpret(Fn)(args...)
+end


### PR DESCRIPTION
This is the PR to avoid the use of `invokelastest`.
 
**DO NOT MERGE!!!** It's still WIP.

Now just as what we've converged before, to permit `do` blocks and function definitions when defining a model via `@model`, we need to make `@generated` able to support comprehensions/nested functions.

Will make slides about how to extend `@generated` tomorrow.