### PR TITLE
Var scope in codegen

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Often these are easier to work with in terms of `particles` (built using [MonteC
 julia> post = dynamicHMC(m(X=truth.X), (y=truth.y,));
 
 julia> particles(post)
-(β = Particles{Float64,1000}[0.558 ± 0.25, 0.768 ± 0.49],)
+(β = Particles{Float64,1000}[0.555 ± 0.26, 0.747 ± 0.47],)
 
 ````
 
@@ -204,11 +204,11 @@ julia> using BenchmarkTools
 
 julia> 
 @btime logpdf($m2(X=X), $truth)
-  802.533 ns (16 allocations: 464 bytes)
+  14.209 μs (52 allocations: 1.25 KiB)
 -15.84854642585797
 
 julia> @btime logpdf($m2(X=X), $truth, $codegen)
-  324.463 ns (5 allocations: 208 bytes)
+  313.663 ns (5 allocations: 208 bytes)
 -15.848546425857968
 
 ````

--- a/src/primitives/rand.jl
+++ b/src/primitives/rand.jl
@@ -5,7 +5,6 @@ export rand
 EmptyNTtype = NamedTuple{(),Tuple{}} where T<:Tuple
 
 @inline function rand(m::JointDistribution)
-    @show getmodule(m.model)
     return _rand(getmodule(m.model), m.model, m.args)
 end
 

--- a/src/primitives/xform.jl
+++ b/src/primitives/xform.jl
@@ -53,7 +53,7 @@ function sourceXform(_data=NamedTuple())
         wrap(kernel) = @q begin
             _result = NamedTuple()
             $kernel
-            as(_result)
+            $as(_result)
         end
 
         buildSource(_m, proc, wrap) |> flatten


### PR DESCRIPTION
There's a trick to handle python objects: https://github.com/cscherrer/Soss.jl/blob/6b666e282cef446fcab1685836a1f4bd05474cf0/src/symbolic/symbolic.jl#L15

```julia
struct PySymPyModule end
GeneralizedGenerated.NGG.@implement GeneralizedGenerated.NGG.Typeable{PySymPyModule}
const sympy = PySymPyModule()
Base.getproperty(::PySymPyModule, s::Symbol) = Base.getproperty(_pysympy, s)
function __init__()
    ...
    global _pysympy = SymPy.sympy
end
```

And I personally think it would benefit a lot to use `$var` instead of `var` if it's not from `Base`, when writing codegen.

 