### PR TITLE
Type infer for module param

### DIFF
--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -22,6 +22,9 @@ bodytype(::Type{Model{A,B}}) where {A,B} = B
 getmodule(::Type{Model{A,B,M}}) where {A,B,M} = from_type(M)
 getmodule(::Model{A,B,M}) where {A,B,M} = from_type(M)
 
+getmoduletypencoding(::Type{Model{A,B,M}}) where {A, B, M} = M()
+getmoduletypencoding(::Model{A,B,M}) where {A,B,M} = M()
+
 function Model(theModule::Module, args, vals, dists, retn)
     M = to_type(theModule)
     A = NamedTuple{Tuple(args)}

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -22,8 +22,8 @@ bodytype(::Type{Model{A,B}}) where {A,B} = B
 getmodule(::Type{Model{A,B,M}}) where {A,B,M} = from_type(M)
 getmodule(::Model{A,B,M}) where {A,B,M} = from_type(M)
 
-getmoduletypencoding(::Type{Model{A,B,M}}) where {A, B, M} = M()
-getmoduletypencoding(::Model{A,B,M}) where {A,B,M} = M()
+getmoduletypencoding(::Type{Model{A,B,M}}) where {A, B, M} = M
+getmoduletypencoding(::Model{A,B,M}) where {A,B,M} = M
 
 function Model(theModule::Module, args, vals, dists, retn)
     M = to_type(theModule)

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -269,3 +269,5 @@ function tower(x)
     end
     return result
 end
+
+TypeLevel = GeneralizedGenerated.TypeLevel

--- a/src/importance.jl
+++ b/src/importance.jl
@@ -3,14 +3,16 @@ using MonteCarloMeasurements
 
 export importanceSample
 @inline function importanceSample(p::JointDistribution, q::JointDistribution, _data)
-    return _importanceSample(getmodule(p.model), p.model, p.args, q.model, q.args, _data)    
+    return _importanceSample(getmoduletypencoding(p.model), p.model, p.args, q.model, q.args, _data)
 end
 
-@gg M function _importanceSample(M::Module, p::Model, _pargs, q::Model, _qargs, _data)  
+@gg M function _importanceSample(M::MT, p::Model, _pargs, q::Model, _qargs, _data) where MT <: TypeLevel{Module}
     p = type2model(p)
     q = type2model(q)
 
-    sourceImportanceSample()(p,q) |> loadvals(_qargs, _data) |> loadvals(_pargs, NamedTuple())
+    Expr(:let,
+        Expr(:(=), :M, from_type(MT)),
+        sourceImportanceSample()(p,q) |> loadvals(_qargs, _data) |> loadvals(_pargs, NamedTuple()))
 end
 
 export sourceImportanceSample

--- a/src/importance.jl
+++ b/src/importance.jl
@@ -6,12 +6,12 @@ export importanceSample
     return _importanceSample(getmoduletypencoding(p.model), p.model, p.args, q.model, q.args, _data)
 end
 
-@gg M function _importanceSample(M::MT, p::Model, _pargs, q::Model, _qargs, _data) where MT <: TypeLevel{Module}
+@gg M function _importanceSample(_::Type{M}, p::Model, _pargs, q::Model, _qargs, _data) where M <: TypeLevel{Module}
     p = type2model(p)
     q = type2model(q)
 
     Expr(:let,
-        Expr(:(=), :M, from_type(MT)),
+        Expr(:(=), :M, from_type(M)),
         sourceImportanceSample()(p,q) |> loadvals(_qargs, _data) |> loadvals(_pargs, NamedTuple()))
 end
 

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -62,15 +62,15 @@ parts(d::iid; N=1000) = map(1:d.size) do j parts(d.dist) end
     return _particles(getmoduletypencoding(m.model), m.model, m.args)
 end
 
-@gg M function _particles(M::MT, _m::Model, _args) where MT <: TypeLevel{Module}
+@gg M function _particles(_::Type{M}, _m::Model, _args) where M <: TypeLevel{Module}
     Expr(:let,
-        Expr(:(=), :M, from_type(MT)),
+        Expr(:(=), :M, from_type(M)),
         type2model(_m) |> sourceParticles() |> loadvals(_args, NamedTuple()))
 end
 
-@gg M function _particles(M::MT, _m::Model, _args::NamedTuple{()}) where MT <: TypeLevel{Module}
+@gg M function _particles(_::Type{M}, _m::Model, _args::NamedTuple{()}) where M <: TypeLevel{Module}
     Expr(:let,
-        Expr(:(=), :M, from_type(MT)),
+        Expr(:(=), :M, from_type(M)),
         type2model(_m) |> sourceParticles())
 end
 

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -59,15 +59,19 @@ parts(d::iid; N=1000) = map(1:d.size) do j parts(d.dist) end
 
 
 @inline function particles(m::JointDistribution)
-    return _particles(getmodule(m.model), m.model, m.args)
+    return _particles(getmoduletypencoding(m.model), m.model, m.args)
 end
 
-@gg M function _particles(M::Module, _m::Model, _args) 
-    type2model(_m) |> sourceParticles() |> loadvals(_args, NamedTuple())
+@gg M function _particles(M::MT, _m::Model, _args) where MT <: TypeLevel{Module}
+    Expr(:let,
+        Expr(:(=), :M, from_type(MT)),
+        type2model(_m) |> sourceParticles() |> loadvals(_args, NamedTuple()))
 end
 
-@gg M function _particles(M::Module, _m::Model, _args::NamedTuple{()})
-    type2model(_m) |> sourceParticles()
+@gg M function _particles(M::MT, _m::Model, _args::NamedTuple{()}) where MT <: TypeLevel{Module}
+    Expr(:let,
+        Expr(:(=), :M, from_type(MT)),
+        type2model(_m) |> sourceParticles())
 end
 
 export sourceParticles

--- a/src/primitives/likelihood-weighting.jl
+++ b/src/primitives/likelihood-weighting.jl
@@ -2,11 +2,13 @@
 export weightedSample
 
 function weightedSample(m::JointDistribution, _data) 
-    return _weightedSample(getmodule(m.model), m.model, m.args, _data)    
+    return _weightedSample(getmoduletypencoding(m.model), m.model, m.args, _data)    
 end
 
-@gg M function _weightedSample(M::Module, _m::Model, _args, _data) 
-    type2model(_m) |> sourceWeightedSample(_data) |> loadvals(_args, _data)
+@gg M function _weightedSample(M::MT, _m::Model, _args, _data) where MT <: TypeLevel{Module}
+    Expr(:let,
+        Expr(:(=), :M, from_type(MT)),
+        type2model(_m) |> sourceWeightedSample(_data) |> loadvals(_args, _data))
 end
 
 function sourceWeightedSample(_data)

--- a/src/primitives/likelihood-weighting.jl
+++ b/src/primitives/likelihood-weighting.jl
@@ -5,9 +5,9 @@ function weightedSample(m::JointDistribution, _data)
     return _weightedSample(getmoduletypencoding(m.model), m.model, m.args, _data)    
 end
 
-@gg M function _weightedSample(M::MT, _m::Model, _args, _data) where MT <: TypeLevel{Module}
+@gg M function _weightedSample(_::Type{M}, _m::Model, _args, _data) where M <: TypeLevel{Module}
     Expr(:let,
-        Expr(:(=), :M, from_type(MT)),
+        Expr(:(=), :M, from_type(M)),
         type2model(_m) |> sourceWeightedSample(_data) |> loadvals(_args, _data))
 end
 

--- a/src/primitives/logpdf.jl
+++ b/src/primitives/logpdf.jl
@@ -11,9 +11,9 @@ end
 
 
 
-@gg M function _logpdf(M::MT, _m::Model, _args, _data) where MT <: TypeLevel{Module}
+@gg M function _logpdf(_::Type{M}, _m::Model, _args, _data) where M <: TypeLevel{Module}
     Expr(:let,
-        Expr(:(=), :M, from_type(MT)),
+        Expr(:(=), :M, from_type(M)),
         type2model(_m) |> sourceLogpdf() |> loadvals(_args, _data))
 end
 

--- a/src/primitives/logpdf.jl
+++ b/src/primitives/logpdf.jl
@@ -2,17 +2,19 @@
 export logpdf
 
 function logpdf(m::JointDistribution{A0,A,B,M},x) where {A0,A,B,M}
-    _logpdf(from_type(M), m.model, m.args, x)
+    _logpdf(M, m.model, m.args, x)
 end
 
 function logpdf(m::JointDistribution{A0,A,B,M},x, ::typeof(logpdf)) where {A0,A,B,M}
-    _logpdf(from_type(M), m.model, m.args, x)
+    _logpdf(M, m.model, m.args, x)
 end
 
 
 
-@gg M function _logpdf(M::Module, _m::Model, _args, _data)  
-    type2model(_m) |> sourceLogpdf() |> loadvals(_args, _data)
+@gg M function _logpdf(M::MT, _m::Model, _args, _data) where MT <: TypeLevel{Module}
+    Expr(:let,
+        Expr(:(=), :M, from_type(MT)),
+        type2model(_m) |> sourceLogpdf() |> loadvals(_args, _data))
 end
 
 function sourceLogpdf()

--- a/src/primitives/rand.jl
+++ b/src/primitives/rand.jl
@@ -1,23 +1,26 @@
 using GeneralizedGenerated
 
 export rand
-
 EmptyNTtype = NamedTuple{(),Tuple{}} where T<:Tuple
 
 @inline function rand(m::JointDistribution)
-    return _rand(getmodule(m.model), m.model, m.args)
+    return _rand(getmoduletypencoding(m.model), m.model, m.args)
 end
 
 @inline function rand(m::Model)
-    return _rand(getmodule(m), m, NamedTuple())
+    return _rand(getmoduletypencoding(m), m, NamedTuple())
 end
 
-@gg M function _rand(M::Module, _m::Model, _args) 
-    type2model(_m) |> sourceRand() |> loadvals(_args, NamedTuple())
+@gg M function _rand(M::MT, _m::Model, _args) where MT <: TypeLevel{Module}
+    Expr(:let,
+        Expr(:(=), :M, from_type(MT)),
+        type2model(_m) |> sourceRand() |> loadvals(_args, NamedTuple()))
 end
 
-@gg M function _rand(M::Module, _m::Model, _args::NamedTuple{()})
-    type2model(_m) |> sourceRand()
+@gg M function _rand(M::MT, _m::Model, _args::NamedTuple{()}) where MT <: TypeLevel{Module}
+    Expr(:let,
+        Expr(:(=), :M, from_type(MT)),
+        type2model(_m) |> sourceRand())
 end
 
 export sourceRand

--- a/src/primitives/rand.jl
+++ b/src/primitives/rand.jl
@@ -11,15 +11,15 @@ end
     return _rand(getmoduletypencoding(m), m, NamedTuple())
 end
 
-@gg M function _rand(M::MT, _m::Model, _args) where MT <: TypeLevel{Module}
+@gg M function _rand(_::Type{M}, _m::Model, _args) where M <: TypeLevel{Module}
     Expr(:let,
-        Expr(:(=), :M, from_type(MT)),
+        Expr(:(=), :M, from_type(M)),
         type2model(_m) |> sourceRand() |> loadvals(_args, NamedTuple()))
 end
 
-@gg M function _rand(M::MT, _m::Model, _args::NamedTuple{()}) where MT <: TypeLevel{Module}
+@gg M function _rand(_::Type{M}, _m::Model, _args::NamedTuple{()}) where M <: TypeLevel{Module}
     Expr(:let,
-        Expr(:(=), :M, from_type(MT)),
+        Expr(:(=), :M, from_type(M)),
         type2model(_m) |> sourceRand())
 end
 

--- a/src/primitives/xform.jl
+++ b/src/primitives/xform.jl
@@ -15,9 +15,9 @@ function xform(m::JointDistribution{A, B}, _data) where {A,B}
     return _xform(getmoduletypencoding(m.model), m.model, m.args, _data)
 end
 
-@gg M function _xform(M::MT, _m::Model{Asub,B}, _args::A, _data) where {MT <: TypeLevel{Module}, Asub, A,B}
+@gg M function _xform(_::Type{M}, _m::Model{Asub,B}, _args::A, _data) where {M <: TypeLevel{Module}, Asub, A,B}
     Expr(:let,
-        Expr(:(=), :M, from_type(MT)),
+        Expr(:(=), :M, from_type(M)),
         type2model(_m) |> sourceXform(_data) |> loadvals(_args, _data))
 end
 

--- a/src/primitives/xform.jl
+++ b/src/primitives/xform.jl
@@ -12,11 +12,13 @@ export xform
 
 
 function xform(m::JointDistribution{A, B}, _data) where {A,B}
-    return _xform(getmodule(m.model), m.model, m.args, _data)    
+    return _xform(getmoduletypencoding(m.model), m.model, m.args, _data)
 end
 
-@gg M function _xform(M::Module, _m::Model{Asub,B}, _args::A, _data) where {Asub, A,B} 
-    type2model(_m) |> sourceXform(_data) |> loadvals(_args, _data)
+@gg M function _xform(M::MT, _m::Model{Asub,B}, _args::A, _data) where {MT <: TypeLevel{Module}, Asub, A,B}
+    Expr(:let,
+        Expr(:(=), :M, from_type(MT)),
+        type2model(_m) |> sourceXform(_data) |> loadvals(_args, _data))
 end
 
 # function xform(m::Model{EmptyNTtype, B}) where {B}

--- a/src/symbolic/codegen.jl
+++ b/src/symbolic/codegen.jl
@@ -158,5 +158,5 @@ end
 
 
 function logpdf(m::JointDistribution{A0,A,B,M},x,::typeof(codegen)) where {A0,A,B,M}
-    codegen(M(), m.model, m.args, x)
+    codegen(M, m.model, m.args, x)
 end

--- a/src/symbolic/codegen.jl
+++ b/src/symbolic/codegen.jl
@@ -158,5 +158,5 @@ end
 
 
 function logpdf(m::JointDistribution{A0,A,B,M},x,::typeof(codegen)) where {A0,A,B,M}
-    codegen(from_type(M), m.model, m.args, x)
+    codegen(M(), m.model, m.args, x)
 end

--- a/src/symbolic/reduce.jl
+++ b/src/symbolic/reduce.jl
@@ -15,9 +15,9 @@ function reduce(m::JointDistribution,x)
     return _reduce(getmoduletypencoding(m.model), m.model, m.args, x)
 end
 
-@gg M function _reduce(M::MT, _m::Model, _args, _data) where MT <: TypeLevel{Module}
+@gg M function _reduce(_::Type{M}, _m::Model, _args, _data) where M <: TypeLevel{Module}
     Expr(:let,
-        Expr(:(=), :M, from_type(MT)),
+        Expr(:(=), :M, from_type(M)),
         type2model(_m) |> sourceReduce() |> loadvals(_args, _data))
 end
 

--- a/src/symbolic/reduce.jl
+++ b/src/symbolic/reduce.jl
@@ -12,11 +12,13 @@ end
 export reduce
 
 function reduce(m::JointDistribution,x)
-    return _reduce(getmodule(m.model), m.model, m.args, x)    
+    return _reduce(getmoduletypencoding(m.model), m.model, m.args, x)
 end
 
-@gg M function _reduce(M::Module, _m::Model, _args, _data)  
-    type2model(_m) |> sourceReduce() |> loadvals(_args, _data)
+@gg M function _reduce(M::MT, _m::Model, _args, _data) where MT <: TypeLevel{Module}
+    Expr(:let,
+        Expr(:(=), :M, from_type(MT)),
+        type2model(_m) |> sourceReduce() |> loadvals(_args, _data))
 end
 
 function sourceReduce()

--- a/src/symbolic/symbolic.jl
+++ b/src/symbolic/symbolic.jl
@@ -51,10 +51,10 @@ function __init__()
     ))
 
     @eval begin
-    @gg M function codegen(M::MT, _m::Model, _args, _data) where MT <: TypeLevel{Module}
+    @gg M function codegen(_::Type{M}, _m::Model, _args, _data) where M <: TypeLevel{Module}
         f = _codegen(type2model(_m))
         Expr(:let,
-            Expr(:(=), :M, from_type(MT)),
+            Expr(:(=), :M, from_type(M)),
             :($f(_args, _data)))
     end
 end
@@ -450,9 +450,9 @@ function symlogpdf(m::Model)
     return _symlogpdf(getmoduletypencoding(m), m)
 end
 
-@gg M function _symlogpdf(M::MT, _m::Model) where MT <: TypeLevel{Module}
+@gg M function _symlogpdf(_::Type{M}, _m::Model) where M <: TypeLevel{Module}
     Expr(:let,
-        Expr(:(=), :M, from_type(MT)),
+        Expr(:(=), :M, from_type(M)),
         type2model(_m) |> canonical |> sourceSymlogpdf())
 end
 


### PR DESCRIPTION
Hi Chad, check this?
```julia
julia> m = @model begin
                 x ~ Normal()
             end;

julia> x = 1.0
1.0

julia> truth = rand(m(x=x));

julia> logpdf(m(x=x),truth)
-0.9239165095384807

julia> @code_warntype logpdf(m(x=x),truth)
Variables
  #self#::Core.Compiler.Const(Distributions.logpdf, false)
  m::Soss.JointDistribution{NamedTuple{(:x,),Tuple{Float64}},NamedTuple{(),T} where T<:Tuple,TypeEncoding(begin
    x ~ Normal()
end),TypeEncoding(Main)}
  x::NamedTuple{(:x,),Tuple{Float64}}

Body::Float64
1 ─ %1 = $(Expr(:static_parameter, 4))::Core.Compiler.Const(TypeEncoding(Main), false)
│   %2 = Base.getproperty(m, :model)::Model{NamedTuple{(),T} where T<:Tuple,TypeEncoding(begin
    x ~ Normal()
end),TypeEncoding(Main)}
│   %3 = Base.getproperty(m, :args)::NamedTuple{(:x,),Tuple{Float64}}
│   %4 = Soss._logpdf(%1, %2, %3, x)::Float64
└──      return %4
```

When calling things like `rand`, let the module argument be the type encoded module instead of the module object.