### PR TITLE
[WIP] Specify sample size when sampling with particles

### DIFF
--- a/src/Soss.jl
+++ b/src/Soss.jl
@@ -11,7 +11,6 @@ import MacroTools: prewalk, postwalk, @q, striplines, replace, flatten, @capture
 import MLStyle
 @reexport using MonteCarloMeasurements
 
-using LinearAlgebra
 using LazyArrays
 using FillArrays
 

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -9,9 +9,7 @@ end
 export particles
 
 particles(v::Vector{<:Real}) = Particles(v)
-particles(d) = begin
-    Particles(1000, d)
-end
+particles(d; N=DEFAULT_SAMPLE_SIZE) = Particles(N, d)
 
 # particles(n :: NUTS_result) = particles(n.samples)
 using IterTools

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -38,11 +38,11 @@ parts(x::Integer; N=DEFAULT_SAMPLE_SIZE) = parts(float(x))
 parts(x::Real; N=DEFAULT_SAMPLE_SIZE) = parts(repeat([x],N))
 parts(x::AbstractArray; N=DEFAULT_SAMPLE_SIZE) = Particles(x)
 parts(p::Particles; N=DEFAULT_SAMPLE_SIZE) = p
-parts(d::For; N=DEFAULT_SAMPLE_SIZE) = parts.(d.f.(d.θ...))
+parts(d::For; N=DEFAULT_SAMPLE_SIZE) = parts.(d.f.(d.θ...); N=N)
 
 
 
-parts(d::iid; N=DEFAULT_SAMPLE_SIZE) = map(1:d.size) do j parts(d.dist) end
+parts(d::iid; N=DEFAULT_SAMPLE_SIZE) = map(1:d.size) do j parts(d.dist; N=N) end
 # size
 # dist 
 

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -31,14 +31,14 @@ export parts
 
 # Just a little helper function for particles
 # https://github.com/baggepinnen/MonteCarloMeasurements.jl/issues/22
-parts(d; N=1000) = particles(m)
-parts(x::Normal{P} where {P <: AbstractParticles}; N=1000) = Particles(length(x.μ), Normal()) * x.σ + x.μ
-parts(x::Sampleable{F,S}; N=1000) where {F,S} = Particles(N,x)
-parts(x::Integer; N=1000) = parts(float(x))
-parts(x::Real; N=1000) = parts(repeat([x],N))
-parts(x::AbstractArray; N=1000) = Particles(x)
-parts(p::Particles; N=1000) = p 
-parts(d::For; N=1000) = parts.(d.f.(d.θ...))
+parts(d; N=DEFAULT_SAMPLE_SIZE) = particles(d; N=N)
+parts(x::Normal{P} where {P <: AbstractParticles}; N=DEFAULT_SAMPLE_SIZE) = Particles(length(x.μ), Normal()) * x.σ + x.μ
+parts(x::Sampleable{F,S}; N=DEFAULT_SAMPLE_SIZE) where {F,S} = Particles(N,x)
+parts(x::Integer; N=DEFAULT_SAMPLE_SIZE) = parts(float(x))
+parts(x::Real; N=DEFAULT_SAMPLE_SIZE) = parts(repeat([x],N))
+parts(x::AbstractArray; N=DEFAULT_SAMPLE_SIZE) = Particles(x)
+parts(p::Particles; N=DEFAULT_SAMPLE_SIZE) = p
+parts(d::For; N=DEFAULT_SAMPLE_SIZE) = parts.(d.f.(d.θ...))
 
 
 

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -1,4 +1,4 @@
-
+const DEFAULT_SAMPLE_SIZE = 1000
 
 export sourceParticles
 

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -60,16 +60,16 @@ parts(d::iid; N=DEFAULT_SAMPLE_SIZE) = map(1:d.size) do j parts(d.dist; N=N) end
     return _particles(getmoduletypencoding(m.model), m.model, m.args, Val(N))
 end
 
-@gg M function _particles(_::Type{M}, _m::Model, _args, _n::Val{N}) where {M <: TypeLevel{Module},N}
+@gg M function _particles(_::Type{M}, _m::Model, _args, _n::Val{_N}) where {M <: TypeLevel{Module},_N}
     Expr(:let,
         Expr(:(=), :M, from_type(M)),
-        sourceParticles()(type2model(_m), N) |> loadvals(_args, NamedTuple()))
+        sourceParticles()(type2model(_m), _N) |> loadvals(_args, NamedTuple()))
 end
 
-@gg M function _particles(_::Type{M}, _m::Model, _args::NamedTuple{()}, _n::Val{N}) where {M <: TypeLevel{Module},N}
+@gg M function _particles(_::Type{M}, _m::Model, _args::NamedTuple{()}, _n::Val{_N}) where {M <: TypeLevel{Module},_N}
     Expr(:let,
         Expr(:(=), :M, from_type(M)),
-        sourceParticles()(type2model(_m), N))
+        sourceParticles()(type2model(_m), _N))
 end
 
 export sourceParticles


### PR DESCRIPTION
Currently this doesn't work. Here's an example:

```julia
julia> using Soss;

julia> mod = @model (J) begin
           x ~ Normal() |> iid(J)
       end;

julia> p = particles(mod(J = 3); N = 5)
ERROR: UndefVarError: N not defined
Stacktrace:
 [1] getproperty at ./Base.jl:13 [inlined]
 [2] macro expansion at /Users/saxen/.julia/packages/GeneralizedGenerated/NDqgV/src/closure_conv.jl:121 [inlined]
 [3] _particles(::Type{TypeEncoding(Main)}, ::Model{NamedTuple{(:J,),T} where T<:Tuple,TypeEncoding(begin
    x ~ Normal() |> iid(J)
end),TypeEncoding(Main)}, ::NamedTuple{(:J,),Tuple{Int64}}, ::Val{5}) at /Users/saxen/.julia/packages/GeneralizedGenerated/NDqgV/src/closure_conv.jl:121
 [4] #particles#163 at /Users/saxen/projects/Soss.jl/src/particles.jl:60 [inlined]
 [5] (::Soss.var"#kw##particles")(::NamedTuple{(:N,),Tuple{Int64}}, ::typeof(particles), ::Soss.JointDistribution{NamedTuple{(:J,),Tuple{Int64}},NamedTuple{(:J,),T} where T<:Tuple,TypeEncoding(begin
    x ~ Normal() |> iid(J)
end),TypeEncoding(Main)}) at ./none:0
 [6] top-level scope at REPL[3]:1

julia> mod = @model (N) begin
           x ~ Normal() |> iid(N)
       end;

julia> p = particles(mod(N = 3); N = 5)
(N = 3, x = Particles{Float64,3}[0.0 ± 0.97, 0.0 ± 0.97, 0.0 ± 0.97])

julia> p.x[1]
Part3(0.0 ± 0.967)
```

It appears `N` is somehow being extracted from the `JointDistribution` and passed to `parts`. Hence when the model doesn't have an `N`, an error is thrown, and when it does, the keyword `N` passed to `particles` is ignored.

I suspect I'm doing something silly with the generalized generated function `_particles`. There are other funny things:

```julia
julia> p.x[1].particles
3-element Array{Float64,1}:
 -0.9674215661017014
  0.9674215661017014
  0.0               

julia> p.x[2].particles
3-element Array{Float64,1}:
 -0.9674215661017014
  0.9674215661017014
  0.0               

julia> p.x[3].particles
3-element Array{Float64,1}:
  0.0               
  0.9674215661017014
 -0.9674215661017014
```

@cscherrer any insights?