### PR TITLE
Several distribution improvements

### DIFF
--- a/src/Soss.jl
+++ b/src/Soss.jl
@@ -1,6 +1,7 @@
 module Soss
 
 import Base.rand
+using Random
 using Reexport: @reexport
 
 @reexport using Distributions
@@ -52,11 +53,11 @@ include("inference/advancedhmc.jl")
 
 
 # include("weighted.jl")
-# 
+#
 # # include("graph.jl")
 # # # include("optim.jl")
 # include("importance.jl")
-# 
+#
 # # # include("sobols.jl")
 # # # include("fromcube.jl")
 # # # include("tocube.jl")

--- a/src/distributions/dist.jl
+++ b/src/distributions/dist.jl
@@ -55,7 +55,7 @@ Base.rand(rng::AbstractRNG, m::EqualMix) = rand(rng, rand(rng, m.components))
 xform(d::EqualMix, _data) = xform(d.components[1], _data)
 
 
-StudentT(ν, μ=0.0, σ=1.0) = LocationScale(μ, σ, TDist(ν))
+StudentT(ν, μ = 0.0, σ = 1.0) = LocationScale(μ, σ, TDist(ν))
 
 
 xform(d::Dirichlet, _data) = UnitSimplex(length(d.alpha))

--- a/src/inference/dynamicHMC.jl
+++ b/src/inference/dynamicHMC.jl
@@ -7,8 +7,6 @@ using TransformVariables,
       ForwardDiff
 import LogDensityProblems: ADgradient
 
-using Random
-
 export dynamicHMC
 
 function dynamicHMC(


### PR DESCRIPTION
Some overall improvements to a few distributions in one file
- `HalfNormal` now is a subtype of `Distribution`
- `quantile` works for `HalfNormal` (these two enable `particles(::HalfNormal, ::Int)`
- Add type parameter to `HalfNormal`
- Remove unnecessary constructors
- Remove unused type parameters in methods
- Reformat code (using [JuliaFormatter.jl](https://github.com/domluna/JuliaFormatter.jl))
- `rand` calls now take `AbstractRNG`. `rand(::Distribution)` defaults to calling this using `GLOBAL_RNG`, so the original behavior is preserved.