### PR TITLE
Bump compat for Distributions.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -38,7 +38,7 @@ TransformVariables = "84d833dd-6860-57f9-a1a7-6da5db126cff"
 [compat]
 AdvancedHMC = "0.2"
 DiffResults = "1.0"
-Distributions = "0.21"
+Distributions = "0.21, 0.22"
 DynamicHMC = "2.1"
 FillArrays = "0.8"
 ForwardDiff = "0.10"


### PR DESCRIPTION
This resolves the current inability to have current Turing.jl and Soss.jl in the same environment.