### PR TITLE
Reconciled arguments

### DIFF
--- a/src/transforms/prune.jl
+++ b/src/transforms/prune.jl
@@ -11,8 +11,9 @@ function prune(m::Model, xs :: Symbol...)
         setdiff!(newvars, [x])
     end
 
-    # TODO: Check if some of these are no longer used
-    newargs = arguments(m)
+    # Removes unused arguments, removes arguments from variable list.
+    newargs = arguments(m) ∩ newvars
+    setdiff!(newvars, newargs)
 
     theModule = getmodule(m)
     m_init = Model(theModule, newargs, NamedTuple(), NamedTuple(), nothing)


### PR DESCRIPTION
Same pattern as `predictive()` should work here too.

```julia
julia> m = @model X begin
        k = 4
        β ~ Normal() |> iid(k)
        yhat = X * β
        N = size(X, 1)
        y ~ For(N) do j
                Normal(yhat[j], 1)
            end
      end;

julia> prune(m, :yhat)
@model X begin
        k = 4
        β ~ Normal() |> iid(k)
        N = size(X, 1)
    end


julia> prune(m, :k)
@model X begin
        N = size(X, 1)
    end


julia> prune(m, :X)
@model begin
        k = 4
        β ~ Normal() |> iid(k)
    end
```