### PR TITLE
importing specific functions from SimpleGraphs to fix name clashes

### DIFF
--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -2,11 +2,11 @@ export Model, @model
 using MLStyle
 
 using MacroTools: @q, striplines
-using SimpleGraphs
+
 using SimplePosets
 using GeneralizedGenerated
 
-struct Model{A,B,M} 
+struct Model{A,B,M}
     args  :: Vector{Symbol}
     vals  :: NamedTuple
     dists :: NamedTuple
@@ -41,20 +41,20 @@ end
 
 function emptyModel(theModule::Module)
     M = to_type(theModule)
-    A = NamedTuple{(),Tuple{}}                    
+    A = NamedTuple{(),Tuple{}}
     B = (@q begin end) |> to_type
     Model{A,B,M}([], NamedTuple(), NamedTuple(), nothing)
 end
 
 
-function Base.merge(m1::Model, m2::Model) 
+function Base.merge(m1::Model, m2::Model)
     theModule = getmodule(m1)
     @assert theModule == getmodule(m2)
     vals = merge(m1.vals, m2.vals)
     args = setdiff(union(m1.args, m2.args), keys(vals))
     dists = merge(m1.dists, m2.dists)
     retn = maybesomething(m2.retn, m1.retn) # m2 first so it gets priority
-  
+
     Model(theModule, args, vals, dists, retn)
 end
 
@@ -125,7 +125,7 @@ end
 
 macro model(expr :: Expr)
     theModule = __module__
-    Model(theModule,Vector{Symbol}(), expr) 
+    Model(theModule,Vector{Symbol}(), expr)
 end
 
 
@@ -164,7 +164,7 @@ end
 # function Base.get(m::Model, k::Symbol)
 #     result = []
 
-#     if k ∈ keys(m.vals) 
+#     if k ∈ keys(m.vals)
 #         push!(result, Assign(k,getproperty(m.vals, k)))
 #     elseif k ∈ keys(m.dists)
 #         if k ∈ keys(m.data)

--- a/src/core/toposort.jl
+++ b/src/core/toposort.jl
@@ -1,5 +1,5 @@
 using SimplePosets
-using SimpleGraphs
+import SimpleGraphs: SimpleGraph, AbstractSimpleGraph, SimpleDigraph, vertex_type, NV, elist, in_neighbors, add_edges!
 
 import Graphs
 import Graphs.simple_graph, Graphs.add_edge!, Graphs.topological_sort_by_dfs

--- a/src/core/toposort.jl
+++ b/src/core/toposort.jl
@@ -1,5 +1,5 @@
 using SimplePosets
-import SimpleGraphs: SimpleGraph, AbstractSimpleGraph, SimpleDigraph, vertex_type, NV, elist, in_neighbors, add_edges!
+using SimpleGraphs: SimpleGraph, AbstractSimpleGraph, SimpleDigraph, vertex_type, NV, elist, in_neighbors, add_edges!
 
 import Graphs
 import Graphs.simple_graph, Graphs.add_edge!, Graphs.topological_sort_by_dfs

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -1,5 +1,4 @@
 using MLStyle
-using SimpleGraphs
 using SimplePosets
 
 expr(x) = :(identity($x))
@@ -35,7 +34,7 @@ parameters(m::Model) = union(assigned(m), sampled(m))
 export variables
 variables(m::Model) = union(arguments(m), parameters(m))
 
-function variables(expr :: Expr) 
+function variables(expr :: Expr)
     leaf(x::Symbol) = begin
         [x]
     end
@@ -50,7 +49,7 @@ variables(s::Symbol) = [s]
 variables(x) = []
 
 for f in [:arguments, :assigned, :sampled, :parameters, :variables]
-    @eval function $f(m::Model, nt::NamedTuple) 
+    @eval function $f(m::Model, nt::NamedTuple)
         vs = $f(m)
         isempty(vs) && return NamedTuple()
         return select(nt, $f(m))
@@ -59,7 +58,7 @@ end
 
 
 export foldall
-function foldall(leaf, branch; kwargs...) 
+function foldall(leaf, branch; kwargs...)
     function go(ast)
         MLStyle.@match ast begin
             Expr(head, args...) => branch(head, map(go, args); kwargs...)
@@ -71,7 +70,7 @@ function foldall(leaf, branch; kwargs...)
 end
 
 export foldall1
-function foldall1(leaf, branch; kwargs...) 
+function foldall1(leaf, branch; kwargs...)
     function go(ast)
         MLStyle.@match ast begin
             Expr(head, arg1, args...) => branch(head, arg1, map(go, args); kwargs...)
@@ -148,7 +147,7 @@ end
 # From https://github.com/thautwarm/MLStyle.jl/issues/66
 @active LamExpr(x) begin
            @match x begin
-               :($a -> begin $(bs...) end) => 
+               :($a -> begin $(bs...) end) =>
                  let exprs = filter(x -> !(x isa LineNumberNode), bs)
                    if length(exprs) == 1
                      (a, exprs[1])
@@ -225,8 +224,8 @@ function loadvals(argstype, datatype, parstype)
 end
 
 
-getntkeys(::NamedTuple{A,B}) where {A,B} = A 
-getntkeys(::Type{NamedTuple{A,B}}) where {A,B} = A 
+getntkeys(::NamedTuple{A,B}) where {A,B} = A
+getntkeys(::Type{NamedTuple{A,B}}) where {A,B} = A
 
 
 # These macros quickly define additional methods for when you get tired of typing `NamedTuple()`
@@ -249,11 +248,11 @@ end
 
 # julia> tower(Int)
 # 6-element Array{DataType,1}:
-#  Int64  
-#  Signed 
+#  Int64
+#  Signed
 #  Integer
-#  Real   
-#  Number 
+#  Real
+#  Number
 #  Any
 
 export tower
@@ -262,7 +261,7 @@ function tower(x)
     t0 = typeof(x)
     result = [t0]
     t1 = supertype(t0)
-    while t1 ≠ t0 
+    while t1 ≠ t0
         push!(result, t1)
         t0, t1 = t1, supertype(t1)
     end


### PR DESCRIPTION
Testing caused some name clashes between `Distributions` and `SimpleGraphs` (#120). I imported the specific functions used from `SimpleGraphs` in core/toposort. They aren't used in core/model or core/utils so I removed that dependency.

Those are the only changes; git detects more in the diff but that's a false positive.

P.S. Let me know if I should merge into something other than master; I don't see dev anymore.