### PR TITLE
Copying Distribution's conventions for one-parameter specifications

### DIFF
--- a/src/symbolic/symbolic.jl
+++ b/src/symbolic/symbolic.jl
@@ -105,6 +105,21 @@ for dist in [:Normal, :Cauchy, :Laplace, :Beta, :Uniform]
     end
 end
 
+for dist in [:Normal, :Cauchy, :Laplace]
+    @eval begin
+        function Distributions.$dist(μ::Sym)
+            Distributions.$dist(μ, 1)
+        end
+    end
+end
+
+for dist in [:Beta]
+    @eval begin
+        function Distributions.$dist(α::Sym)
+            Distributions.$dist(α, α)
+        end
+    end
+end
 
 export sym
 sym(s::Symbol) = sympy.symbols(s, real=true)
@@ -191,7 +206,7 @@ function atoms(s::Sym)
         ixs = [j.args[1] for j in s.args[2:end]]
         bounds = union([j.args[2:3] for j in s.args[2:end]]...)
         return setdiff(union(atoms(summand), atoms.(bounds)...), ixs)
-    end 
+    end
     result = union(map(atoms, s.args)...)
     return result
 end
@@ -240,7 +255,7 @@ function symvar(st::Sample)
     st.rhs.args[1] ∈ [:For, :iid] && return :($sympy.IndexedBase($(st.x)))
     return :($sym($(st.x)))
 end
-    
+
 
 export sourceSymlogpdf
 function sourceSymlogpdf()


### PR DESCRIPTION
Playing around with the symbolic logpdfs using lazy defaults. I think it's convenient to try to match this behavior and make `logpdf` and `symlogpdf` behave the same since most users will be familiar with `Distributions`. Thoughts?

```julia
m = @model x begin
    y ~ Normal(x) # Normal(x,1) according to Distributions, same for Laplace, Cauchy,...
    z ~ Beta(x) # Beta(x,x)
end
```