### PR TITLE
Make `rand` only return parameters (not arguments)

### DIFF
--- a/README.jmd
+++ b/README.jmd
@@ -54,7 +54,8 @@ X = randn(6,2)
 ```
 
 ```julia; term=true
-truth = rand(m(X=X));
+args = (X=X,)
+truth = merge(args, rand(m(X=X)));
 pairs(truth)
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ julia> X = randn(6,2)
 
 
 ````julia
-julia> truth = rand(m(X=X));
+julia> args = (X=X,)
+(X = [1.1915557734285787 0.10079289135480324; -2.5197330871745263 -0.0019741367391015213; … ; -0.1016067940589428 1.158074626662026; -1.5425131978228126 -0.47515878362112707],)
+
+julia> truth = merge(args, rand(m(X=X)));
 
 julia> pairs(truth)
 pairs(::NamedTuple) with 3 entries:
@@ -209,11 +212,11 @@ julia> using BenchmarkTools
 
 julia> 
 @btime logpdf($m2(X=X), $truth)
-  1.957 μs (54 allocations: 1.27 KiB)
+  2.032 μs (54 allocations: 1.27 KiB)
 -15.84854642585797
 
 julia> @btime logpdf($m2(X=X), $truth, $codegen)
-  291.837 ns (5 allocations: 208 bytes)
+  294.723 ns (5 allocations: 208 bytes)
 -15.848546425857968
 
 ````

--- a/src/primitives/rand.jl
+++ b/src/primitives/rand.jl
@@ -35,7 +35,7 @@ function sourceRand()
         proc(_m, st::Return)  = :(return $(st.rhs))
         proc(_m, st::LineNumber) = nothing
 
-        vals = map(x -> Expr(:(=), x,x),variables(_m)) 
+        vals = map(x -> Expr(:(=), x,x),parameters(_m)) 
 
         wrap(kernel) = @q begin
             $kernel


### PR DESCRIPTION
Considering this **BREAKING CHANGE**:

```julia
julia> m = @model μ begin
       x ~ Normal(μ,1)
       y ~ Normal(x,1)
       end;

julia> rand(m(μ=0.0))
(x = 0.34250271693437423, y = -0.25309801842268603)
```

Note `μ` is not included in the output.

This is better in line with the "models are like functions" way of thinking, and it better matches the way most samplers do things. It also gives more concise output - for very complex models this can sometimes become cluttered.

For example, this used to be unwieldy:
```julia
julia> m2 = @model dist begin
       x ~ dist(0)
       y ~ dist(x)
       end;

julia> rand(m2(dist = μ -> Normal(μ,1)))
(x = -0.7289200957591913, y = -0.09546499532869557)
```

Much better now :)

This doesn't come for free... In the README, we now have 
```julia
args = (X=X,)
truth = merge(args, rand(m(X=X)));
```

which had been just `truth = rand(m(X=X))`.