### PR TITLE
Fixed merge and transforms so they handle return values. Updated Tests.

### DIFF
--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -53,9 +53,19 @@ function Base.merge(m1::Model, m2::Model)
     vals = merge(m1.vals, m2.vals)
     args = setdiff(union(m1.args, m2.args), keys(vals))
     dists = merge(m1.dists, m2.dists)
-    retn = maybesomething(m2.retn, m1.retn) # m2 first so it gets priority
+    retn = merge_retn(m2.retn, m1.retn) # m2 first so it gets priority
 
     Model(theModule, args, vals, dists, retn)
+end
+
+function merge_retn(ret1, ret2)
+    if isnothing(ret1)
+        return ret2
+    elseif isnothing(ret2)
+        return ret1
+    else
+        return :(($ret1,$ret2))
+    end
 end
 
 Base.merge(m::Model, ::Nothing) = m

--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -53,8 +53,7 @@ function Base.merge(m1::Model, m2::Model)
     vals = merge(m1.vals, m2.vals)
     args = setdiff(union(m1.args, m2.args), keys(vals))
     dists = merge(m1.dists, m2.dists)
-    retn = merge_retn(m2.retn, m1.retn) # m2 first so it gets priority
-
+    retn = merge_retn(m1.retn, m2.retn)
     Model(theModule, args, vals, dists, retn)
 end
 

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -4,11 +4,6 @@ using SimplePosets
 expr(x) = :(identity($x))
 
 # like `something`, but doesn't throw an error
-maybesomething() = nothing
-maybesomething(x::Nothing, y...) = maybesomething(y...)
-maybesomething(x::Some, y...) = x.value
-maybesomething(x::Any, y...) = x
-
 
 export argtuple
 argtuple(m) = arguments(m) |> astuple

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -11,6 +11,7 @@ m = @model (n,α,β) begin
     p ~ Beta(α, β)
     x ~ Binomial(n, p)
     z ~ Binomial(n, α/(α+β))
+    return p,x,z
 end
 
 @testset "prior" begin
@@ -18,12 +19,15 @@ end
     @test Soss.prior(m, :x) ≊ @model (n,α,β) begin
         p ~ Beta(α, β)
         x ~ Binomial(n, p)
+        return (p,x)
     end
     @test Soss.prior(m1, :p) ≊ @model (α, β) begin
         p ~ Beta(α, β)
+        return p
     end
     @test Soss.prior(m, :z) ≊ @model (n, α, β) begin
         z ~ Binomial(n, α / (α + β))
+        return z
     end
 end
 
@@ -31,12 +35,15 @@ m1 = prune(m, :z)
 @testset "prune" begin
     @test prune(m, :x, :z) ≊ @model (α, β) begin
         p ~ Beta(α, β)
+        return p
     end
     @test prune(m1, :n) ≊ @model (α, β) begin
         p ~ Beta(α, β)
+        return p
     end
     @test prune(m, :p) ≊ @model (α, n, β) begin
         z ~ Binomial(n, α / (α + β))
+        return z
     end
 
     # When I define these variables, the tests pass.
@@ -48,12 +55,14 @@ end
 @testset "predictive" begin
     @test predictive(m, :p) ≊ @model (n, p) begin
         x ~ Binomial(n, p)
+        return (p,x)
     end
 end
 
 @testset "Do" begin
     @test Do(m, :p, :z) ≊ @model (n, p) begin
         x ~ Binomial(n, p)
+        return (p,x)
     end
     empty = @model begin end
     @test Do(m, variables(m)...) ≊ empty


### PR DESCRIPTION
[Draft/WIP. Just for notes and discussion.]

I'm trying to modify the transforms to handle their `return` in the expected way. To do this, it was easiest to make `merge` combine the return values via `merge_retn`. Note that [`merge_retn`](https://github.com/cscherrer/Soss.jl/compare/cscherrer:cc41ed7...cscherrer:b5013be#diff-63225b38a8672adee82ed4431c2c9ae3R60-R69) (copied below) is awkward since it duplicates the return values if both are present:
```julia
julia> function merge_retn(ret1, ret2)
    if isnothing(ret1)
        return ret2
    elseif isnothing(ret2)
        return ret1
    else
        return :(($ret1,$ret2))
    end
end

julia> m = @model begin x ~ Normal(); return x end;

julia> merge_retn(m,m)

julia> merge(m,m)
@model begin
        x ~ Normal()
        return (x, x)
    end
```

There's also no canonical order of the return values so `merge(m1,m2) != merge(m2, m1)` in general.

These are easy enough (in theory) to straighten up, but I'm not sure what we should want `merge` to do with the returns in goofy cases where calculations are done and returned or identifiers are obfuscated (or reused):
```julia
julia> m1 = @model k begin
        u ~ Uniform(0,1)
        return [u,-1/k*log(u)]
    end;

julia> m2 = @model k begin
        ux ~ m1(k=k)
        return [ux[1], ux[2]]
end;

julia> merge(m1, m2)
@model k begin
        u ~ Uniform(0, 1)
        ux ~ m1(k = k)
        return ([u, (-1 / k) * log(u)], [ux[1], ux[2]])
    end
```

To simplify some of this, I made the transform functions [complain](https://github.com/cscherrer/Soss.jl/compare/transforms_return_compatibility?expand=1#diff-12eca3e3e46226b714489cbc39eb164eR68) if the returned `Expr` isn't a `Tuple` (if it's a `Symbol`, no issue), . If it is, I prune away elements of that Tuple that contain the old variables too, since if these were moved into the body, they'd be pruned:
```julia
julia> m3 = @model begin
        b ~ Normal()
        a ~ Normal()
        return (a, b, a + b)
    end

julia> prune(m3, :b)
@model begin
        a ~ Normal()
        return a
    end
```

Unfortunately, these `return` calculations mess up `predictive`, since only the body of the model is used to find each statement's "children":
```julia
julia> predictive(m3, :a,:b)
@model begin
    end
```

## Questions/Proposals

1. Should `merge` be symmetric? If so, are there any natural ways of imposing a canonical order on expressions?

2. How should we think of the `return`ed expression? It solves the above ambiguities if we make returned `Tuples` and computations consistent with assigning and returning new temporary variables since it'll imply a unique dependency graph of all the statements/variables. Then we can just reuse the `Digraph` logic for dependencies. So

```julia
@model args begin
v1 ~ Dist(args)
v2 ~ ....
...
return f(v1,v2,...,args), f(v1,v2,...,args)
```
behaves the same as
```julia
@model args begin
v1 ~ Dist(args)
v2 ~ ....
...
w1 = f(v1,v2,...,args)
w2 = f(v1,v2,...,args)
return w1,w2
end
```