### PR TITLE
Require the latest version of GeneralizedGenerated

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Soss"
 uuid = "8ce77f84-9b61-11e8-39ff-d17a774bf41c"
 author = ["Chad Scherrer <chad.scherrer@gmail.com>"]
-version = "0.13.0"
+version = "0.13.1"
 
 [deps]
 AdvancedHMC = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
@@ -43,7 +43,7 @@ Distributions = "0.21, 0.22, 0.23"
 DynamicHMC = "2.1"
 FillArrays = "0.8"
 ForwardDiff = "0.10"
-GeneralizedGenerated = "0.2"
+GeneralizedGenerated = "0.2.6"
 Graphs = "0.10"
 IterTools = "1.3"
 LazyArrays = "0.14, 0.15, 0.16"


### PR DESCRIPTION
This pull request:
1. Requires GeneralizedGenerated `0.2.6`
2. Bumps the Soss version number from `0.13.0` to `0.13.1`, which will allow us to make a patch release once this PR is merged.

Note that the base branch for this pull request is `release/0.13`. It is not `master`; the version number in `master` is `0.14.0`, because `master` will become the next breaking release of Soss.

cc: @cscherrer 