### PR TITLE
add .~ notation

### DIFF
--- a/src/core/model.jl
+++ b/src/core/model.jl
@@ -72,6 +72,7 @@ function Model(theModule::Module, expr :: Expr)
     @match expr begin
         :($k = $v)   => Model(theModule, Assign(k,v))
         :($k ~ $v)   => Model(theModule, Sample(k,v))
+        :($k .~ $v)  => Model(theModule, Sample(k, :(For(identity, $v))))
         Expr(:return, x...) => Model(theModule, Return(x[1]))
         Expr(:block, body...) => foldl(merge, map(body) do line Model(theModule, line) end)
         :(@model $lnn $body) => Model(theModule, body)


### PR DESCRIPTION
This one-line update (obvious in retrospect) lets us do things like

```julia
julia> m = @model begin
       x .~ Normal.(rand(4))
       end;

julia> m
@model begin
        x ~ For(identity, Normal.(rand(4)))
    end


julia> rand(m())
(x = [0.3757908068715139, 1.7752927895608144, 0.13911698109223786, -0.1342542512198157],)
```

as discussed (two years ago!) in https://github.com/cscherrer/Soss.jl/issues/14

@DilumAluthge I think this will also be useful for our `MLJBase.UnivariateFinite` manipulations