### PR TITLE
More methods for `For` - Take 2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Soss"
 uuid = "8ce77f84-9b61-11e8-39ff-d17a774bf41c"
 author = ["Chad Scherrer <chad.scherrer@gmail.com>"]
-version = "0.14.5"
+version = "0.15.0"
 
 [deps]
 AdvancedHMC = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Soss"
 uuid = "8ce77f84-9b61-11e8-39ff-d17a774bf41c"
 author = ["Chad Scherrer <chad.scherrer@gmail.com>"]
-version = "0.14.4"
+version = "0.14.5"
 
 [deps]
 AdvancedHMC = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"

--- a/src/distributions/for.jl
+++ b/src/distributions/for.jl
@@ -141,7 +141,7 @@ end
 end
 
 @inline function Base.rand(rng::AbstractRNG, d::For{F,T,D,X}) where {F,T<:Base.Generator,D,X}
-    return Base.Generator(rand ∘ d.f ∘ d.θ.f, d.θ.iter)
+    return rand.(rng, Base.Generator(d.f ∘ d.θ.f, d.θ.iter))
 end
 
 @inline function Base.collect(d::For{F,T,D,X}) where {F,T<:Base.Generator,D,X}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,24 @@ include("examples-list.jl")
         end
     end
 
+    @testset "`For` methods" begin
+        @info "Testing `For` methods"
+        for indices in [3, 1:3, (j for j in 1:3), [1,2,3], rand(2,3)]
+            d = For(i -> Normal(0.0, i), indices)
+
+            x = logpdf(d, rand(d))
+            y = logpdf(d, rand.(collect(d)))
+        end
+    
+        for indices in [(2,3), (1:2,1:3)]
+            d = For((i,j) -> Normal(i,j), indices)
+    
+            x = logpdf(d, rand(d))
+            y = logpdf(d, rand.(collect(d)))
+        end    
+    end
+
+
     @testset "Doctests" begin
         include("doctests.jl")
     end


### PR DESCRIPTION
I found the problem!

I had been trying

```julia
@inline function Base.rand(rng::AbstractRNG, d::For{F,T,D,X}) where {F,T<:Base.Generator,D,X}
    return Base.Generator(rand ∘ d.f ∘ d.θ.f, d.θ.iter))
end
```

There were two problems here:

1. It doesn't use `rng`, and
2. When we did `data = rand(m(X=X))`, the generator would rebuild each time, so the data would change each time we looked at it!

I'd like to get back to have the result in a `Base.Generator` (so the types match) but for now I have it as

```julia
@inline function Base.rand(rng::AbstractRNG, d::For{F,T,D,X}) where {F,T<:Base.Generator,D,X}
    return rand.(rng, Base.Generator(d.f ∘ d.θ.f, d.θ.iter))
end
```

And (at least on my machine) the tests all pass.