### PR TITLE
Fix optional import

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Soss"
 uuid = "8ce77f84-9b61-11e8-39ff-d17a774bf41c"
 author = ["Chad Scherrer <chad.scherrer@gmail.com>"]
-version = "0.17.0"
+version = "0.17.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/samplechains/dynamichmc.jl
+++ b/src/samplechains/dynamichmc.jl
@@ -1,4 +1,4 @@
-using SampleChainsDynamicHMC
+using .SampleChainsDynamicHMC
 using Random
 
 export sample


### PR DESCRIPTION
Currently, loading both Soss and SampleChainsDynamicHMC does not work correctly:
```julia
julia>] add Soss, SampleChainsDynamicHMC
julia> using Soss, SampleChainsDynamicHMC
┌ Warning: Package Soss does not have SampleChainsDynamicHMC in its dependencies:
│ 
│   •  If you have Soss checked out for development and have added SampleChainsDynamicHMC as a
│      dependency but haven't updated your primary environment's manifest file, try Pkg.resolve().
│ 
│   •  Otherwise you may need to report an issue with Soss
│ 
│ Loading SampleChainsDynamicHMC into Soss from project dependency, future warnings for Soss are
└ suppressed.
```

The optional import of SampleChainsDynamicHMC is not correct: As stated in the [documentation of Requires](https://github.com/JuliaPackaging/Requires.jl#requiresjl),
> In the @require block, or any included files, you can use or import the package, but note that you must use the syntax using .Gadfly or import .Gadfly, rather than the usual syntax. Otherwise you will get a warning about Gadfly not being in dependencies.

Unfortunately, AFAIK it is not possible to detect this error when running the tests if the optional dependency is a test dependency.